### PR TITLE
Clandestine methods

### DIFF
--- a/app/controllers/orchestrator/api/systems_controller.rb
+++ b/app/controllers/orchestrator/api/systems_controller.rb
@@ -280,7 +280,7 @@ module Orchestrator
             # the count of each of those types
             def types
                 sys = System.get(id)
-                
+
                 if sys
                     result = {}
                     mods = sys.modules
@@ -309,7 +309,7 @@ module Orchestrator
                 }
             ]
             # We need to support an arbitrary settings hash so have to
-            # work around safe params as per 
+            # work around safe params as per
             # http://guides.rubyonrails.org/action_controller_overview.html#outside-the-scope-of-strong-parameters
             def safe_params
                 settings = params[:settings]

--- a/app/controllers/orchestrator/api/systems_controller.rb
+++ b/app/controllers/orchestrator/api/systems_controller.rb
@@ -243,7 +243,10 @@ module Orchestrator
                         end
 
                         # Remove protected methods
-                        pub = funcs.select { |func| !Core::PROTECTED[func] }
+                        pub = funcs.reject { |func| Core::PROTECTED[func] }
+
+                        # Remove hidden methods
+                        pub -= klass::HIDDEN_METHODS.to_a if defined? klass::HIDDEN_METHODS
 
                         # Provide details on the methods
                         resp = {}

--- a/lib/orchestrator/utilities/clandestine.rb
+++ b/lib/orchestrator/utilities/clandestine.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require 'set'
+
+module Orchestrator
+    # Provide the ability to hide public module methods from being exposed
+    # via the API. This may be used to keep methods accessible for cross-module
+    # comms or internal use, without publishing to external users.
+    #
+    # Methods hidden here may still be executed via the API. To restrict access
+    # in addition to obfuscating use ::Orchestrator::Security.
+    module Clandestine
+        module ClandestineMethods
+            # Hide a method, or set of methods from the API.
+            #
+            # May be used inline with the definition:
+            #
+            #     hidden def foo
+            #         ...
+            #     end
+            #
+            # Or as a declarative syntax for internalising multiple driver
+            # methods:
+            #
+            #     hide :foo, :bar, :baz
+            #
+            def hidden(*methods)
+                methods = methods.map(&:to_sym)
+
+                const_set :HIDDEN_METHODS, Set.new \
+                    unless const_defined? :HIDDEN_METHODS
+
+                if methods.count == 1
+                    method = methods.first
+                    HIDDEN_METHODS << method
+                    method
+                else
+                    HIDDEN_METHODS.merge methods
+                    methods
+                end
+            end
+
+            alias hide hidden
+        end
+
+        module_function
+
+        def included(base)
+            base.prepend ClandestineMethods
+        end
+    end
+end


### PR DESCRIPTION
Adds support for declaring public methods within device drivers and logic modules that are intended for internal use only.