### PR TITLE
Composable settings

### DIFF
--- a/lib/orchestrator/core/mixin.rb
+++ b/lib/orchestrator/core/mixin.rb
@@ -106,8 +106,12 @@ module Orchestrator
                 @__config__.logger
             end
 
-            def setting(name)
-                @__config__.setting(name)
+            def setting(name, merge = nil)
+                if block_given?
+                    @__config__.setting(name, Proc.new)
+                else
+                    @__config__.setting(name, merge)
+                end
             end
 
             # Similar to how you would extract settings. Except it

--- a/lib/orchestrator/system.rb
+++ b/lib/orchestrator/system.rb
@@ -73,6 +73,10 @@ module Orchestrator
             end
         end
 
+        def id
+            @config.id
+        end
+
         def get(mod, index)
             mods = @modules[mod]
             if mods


### PR DESCRIPTION
Adds support for composing settings across instance -> sys -> zones -> dependency inheritance layers.

A binary merge operation may be passed in the form of a symbol or block that will be used to reduce the definitions. This enables setting to compose across the various point of config, override in ways dependent on the values, or follow other arbitrary behaviours as required.

For example, a setting that contains a hash value can be merged across all layers with:
```ruby
setting :my_hash_value, &:merge 
```

Numeric values summed:
```ruby
setting :my_number, :+
```

Boolean reduction:
```ruby
# Any
setting :my_bool, :|

# All
setting :my_bool, :&

# Singular
setting :my_bool, :^
```

List ops:
```ruby
# Set reduction
setting :my_list, :|

# Concatenation
setting :my_list, :+
```

Complex merges, or differing formats across layers can be handled with a block.
```ruby
# Collapse all elements into a set, supporting both list and singular entries
setting(:my_possible_lists) { |a, b| [*a] | [*b] }
```

Change is backwards compatible with existing drivers. When unspecified, the previous behaviour is preserved, returning the first value matched in the lookup path.