### PR TITLE
Automatic node association when creating systems

### DIFF
--- a/app/controllers/orchestrator/api/systems_controller.rb
+++ b/app/controllers/orchestrator/api/systems_controller.rb
@@ -85,7 +85,12 @@ module Orchestrator
             end
 
             def create
-                cs = ControlSystem.new(safe_params)
+                props = safe_params
+
+                # Defaul to local node unless edge explicitly specified
+                props[:edge_id] ||= ::Orchestrator::Remote::NodeId
+
+                cs = ControlSystem.new props
                 save_and_respond cs
             end
 


### PR DESCRIPTION
Makes `edge_id` optional when creating new systems.

In single node systems edge ID provides no additional context. This will default to the local edge ID for system creation making the parameter optional as part of the system create API endpoint.