### PR TITLE
Module ID accessor

### DIFF
--- a/lib/orchestrator/core/mixin.rb
+++ b/lib/orchestrator/core/mixin.rb
@@ -3,6 +3,12 @@
 module Orchestrator
     module Core
         module Mixin
+            # Returns the module id as defined in the database.
+            #
+            # @return [Symbol] the id of the module instance
+            def id
+                @__config__.settings.id.to_sym
+            end
 
             # Returns a wrapper around a shared instance of ::UV::Scheduler
             #


### PR DESCRIPTION
Provides support for all module instances to access their instance id.

This enables a supported method for internal access via `self.id`, or access via a request_proxy from logic modules interacting with other module in the system.